### PR TITLE
Moved product description to be above text area

### DIFF
--- a/components/create-forms/CreateProductForm.tsx
+++ b/components/create-forms/CreateProductForm.tsx
@@ -32,6 +32,9 @@ const CreateProductForm = ({ myStore }: any) => {
 									<label className='block text-sm font-medium leading-6 text-gray-900'>
 										Product Details
 									</label>
+									<p className='mt-3 text-sm leading-6 text-gray-600'>
+										Describe your product
+									</p>
 									<textarea
 										className='block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6'
 										rows={3}
@@ -39,9 +42,6 @@ const CreateProductForm = ({ myStore }: any) => {
 										name='productDetails'
 										required
 									/>
-									<p className='mt-3 text-sm leading-6 text-gray-600'>
-										Describe your product
-									</p>
 								</div>
 
 								{/* <div className="col-span-full">


### PR DESCRIPTION
Moved product description to be above text area instead of below, so it made more sense to the user.
![image](https://github.com/ValentinaValverde/Pyme/assets/108947258/ad6eaa41-4bdb-4756-bdcd-297d19d812c4)
