### PR TITLE
Changed button colors to match theme

### DIFF
--- a/components/ShopProductDetails.tsx
+++ b/components/ShopProductDetails.tsx
@@ -63,6 +63,11 @@ export default function ShopProductDetails({ product }: { product: Product }) {
                     color="primary"
                     fullWidth
                     onClick={addToCartHandler}
+                    style={{ 
+                      borderRadius: '20px', 
+                      backgroundColor: 'oklch(76.172% 0.089459 200.026556 /1)',
+                      color: 'black' 
+                    }}
                   >
                     Add to Cart
                   </Button>

--- a/components/ShopProductItem.tsx
+++ b/components/ShopProductItem.tsx
@@ -43,9 +43,11 @@ export default function ShopProductItem({
       </Link>
       <CardContent style={{ marginTop: 'auto' }}>
         <Link href={`${storeSlug}/product/${product.productSlug}`}>
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
           <Typography variant="h5" component="div">
             {product.productName}
           </Typography>
+        </div>
         </Link>
         <div
           style={{
@@ -61,6 +63,11 @@ export default function ShopProductItem({
           color="primary"
           fullWidth
           onClick={addToCartHandler}
+          style={{
+            borderRadius: '20px',
+            backgroundColor: 'oklch(76.172% 0.089459 200.026556 /1)',
+            color: 'black'
+          }}
         >
           Add to Cart
         </Button>


### PR DESCRIPTION
Used chrome dev tools to find color of each button from Daisy UI themed nav buttons. Applied this color to Material UI buttons and rounded the edges to match nav.
<img width="1262" alt="Screenshot 2024-04-25 at 3 26 10 PM" src="https://github.com/ValentinaValverde/Pyme/assets/108947258/99822077-a5c0-4a3f-b006-4e645d369247">
<img width="1263" alt="Screenshot 2024-04-25 at 4 00 47 PM" src="https://github.com/ValentinaValverde/Pyme/assets/108947258/954eed4a-5d1d-4851-a2ac-04d939598187">
<img width="1281" alt="Screenshot 2024-04-25 at 4 01 05 PM" src="https://github.com/ValentinaValverde/Pyme/assets/108947258/6a7ce641-5896-4a5c-b082-b710f4de9480">
