### PR TITLE
Add dividers between each order on sotre and customer orders

### DIFF
--- a/components/CustomerOrders.tsx
+++ b/components/CustomerOrders.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {
+	  Box,
   Table,
   TableBody,
   TableCell,
@@ -7,6 +8,7 @@ import {
   TableHead,
   TableRow,
   Paper,
+  Divider,
 } from '@mui/material'
 
 const CustomerOrders = ({ orders }: { orders: any[] }) => {
@@ -14,54 +16,70 @@ const CustomerOrders = ({ orders }: { orders: any[] }) => {
     return <h2>No Orders Yet</h2>
   }
   return (
-    <TableContainer component={Paper}>
-      <Table aria-label="simple table">
-        <TableHead>
-          <TableRow>
-            <TableCell style={{ fontWeight: 'bold' }}>Order</TableCell>
-            <TableCell style={{ fontWeight: 'bold' }}>Product</TableCell>
-            <TableCell style={{ fontWeight: 'bold' }}>Image</TableCell>
-            <TableCell style={{ fontWeight: 'bold' }}>Quantity</TableCell>
-            <TableCell style={{ fontWeight: 'bold' }}>Price Per Item</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {orders.map((order: any) => (
-            <React.Fragment key={order.id}>
-              <TableRow>
-                <TableCell colSpan={5} style={{ fontWeight: 'bold' }}>
-                  Order #: {order.id}
-                </TableCell>
-              </TableRow>
-              {order.items.map((item: any) => (
-                <TableRow key={item.productSlug}>
-                  <TableCell></TableCell>
-                  <TableCell>{item.productName}</TableCell>
-                  <TableCell>
-                    <img
-                      loading="lazy"
-                      src={item.productImage}
-                      alt={item.productName}
-                      className="max-w-xs max-h-24"
-                      width={100}
-                      height={100}
-                    />
+    <>
+      <TableContainer component={Paper}>
+        <Table aria-label="simple table">
+          <TableHead>
+            <TableRow>
+              <TableCell style={{ fontWeight: 'bold' }}>Order</TableCell>
+              <TableCell style={{ fontWeight: 'bold' }}>Product</TableCell>
+              <TableCell style={{ fontWeight: 'bold' }}>Image</TableCell>
+              <TableCell style={{ fontWeight: 'bold' }}>Quantity</TableCell>
+              <TableCell style={{ fontWeight: 'bold' }}>
+                Price Per Item
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody></TableBody>
+        </Table>
+
+        {orders.map((order: any) => (
+			<Box marginBottom={2} key={order.id}>
+			<TableContainer component={Paper}>
+			<Table aria-label="simple table"></Table>
+          <Table key={order.id} style={{ marginTop: '20px' }}>
+            <TableBody>
+              <React.Fragment key={order.id}>
+                <TableRow>
+                  <TableCell colSpan={5} style={{ fontWeight: 'bold' }}>
+                    Order #: {order.id}
                   </TableCell>
-                  <TableCell>{item.quantity}</TableCell>
-                  <TableCell>${item.price.toFixed(2)}</TableCell>
                 </TableRow>
-              ))}
-              <TableRow>
-                <TableCell colSpan={4} style={{ fontWeight: 'bold' }}>
-                  Total Price
-                </TableCell>
-                <TableCell>${order.totalPrice.toFixed(2)}</TableCell>
-              </TableRow>
-            </React.Fragment>
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
+                {order.items.map((item: any) => (
+                  <TableRow key={item.productSlug}>
+                    <TableCell></TableCell>
+                    <TableCell>{item.productName}</TableCell>
+                    <TableCell>
+                      <img
+                        loading="lazy"
+                        src={item.productImage}
+                        alt={item.productName}
+                        className="max-w-xs max-h-24"
+                        width={100}
+                        height={100}
+                      />
+                    </TableCell>
+                    <TableCell>{item.quantity}</TableCell>
+                    <TableCell>${item.price.toFixed(2)}</TableCell>
+                  </TableRow>
+                ))}
+                <TableRow>
+                  <TableCell colSpan={4} style={{ fontWeight: 'bold' }}>
+                    Total Price
+                  </TableCell>
+                  <TableCell style={{ fontWeight: 'bold' }}>
+                    ${order.totalPrice.toFixed(2)}
+                  </TableCell>
+                </TableRow>
+              </React.Fragment>
+            </TableBody>
+          </Table>
+      </TableContainer>
+	  <Divider style={{ backgroundColor: 'black', height: '2px', marginTop: '20px', marginBottom: '20px' }} />
+	  </Box>
+		))}
+	  </TableContainer>
+    </>
   )
 }
 

--- a/components/StoreOrders.tsx
+++ b/components/StoreOrders.tsx
@@ -1,68 +1,76 @@
 import React from 'react'
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Paper,
+	  Divider,
+	Table,
+	TableBody,
+	TableCell,
+	TableContainer,
+	TableHead,
+	TableRow,
+	Paper,
+	Box,
 } from '@mui/material'
 
 const StoreOrders = ({ orders }: { orders: any[] }) => {
-  if (orders.length === 0) {
-    return <h2>No Orders Yet</h2>
-  }
-  return (
-    <TableContainer component={Paper}>
-      <Table aria-label="simple table">
-        <TableHead>
-          <TableRow>
-            <TableCell style={{ fontWeight: 'bold' }}>Order</TableCell>
-            <TableCell style={{ fontWeight: 'bold' }}>Product</TableCell>
-            <TableCell style={{ fontWeight: 'bold' }}>Image</TableCell>
-            <TableCell style={{ fontWeight: 'bold' }}>Quantity</TableCell>
-            <TableCell style={{ fontWeight: 'bold' }}>Price Per Item</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {orders.map((order: any) => (
-            <React.Fragment key={order.id}>
-              <TableRow>
-                <TableCell colSpan={5} style={{ fontWeight: 'bold' }}>
-                  Order #: {order.id}
-                </TableCell>
-              </TableRow>
-              {order.items.map((item: any) => (
-                <TableRow key={item.productSlug}>
-                  <TableCell></TableCell>
-                  <TableCell>{item.productName}</TableCell>
-                  <TableCell>
-                    <img
-                      loading="lazy"
-                      src={item.productImage}
-                      alt={item.productName}
-                      className="max-w-xs max-h-24"
-                      width={100}
-                      height={100}
-                    />
-                  </TableCell>
-                  <TableCell>{item.quantity}</TableCell>
-                  <TableCell>${item.price.toFixed(2)}</TableCell>
-                </TableRow>
-              ))}
-              <TableRow>
-                <TableCell colSpan={4} style={{ fontWeight: 'bold' }}>
-                  Total Price
-                </TableCell>
-                <TableCell>${order.totalPrice.toFixed(2)}</TableCell>
-              </TableRow>
-            </React.Fragment>
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
-  )
+	if (orders.length === 0) {
+		return <h2>No Orders Yet</h2>
+	}
+	return (
+	{orders.map((order: any, index: number) => (
+		<Box marginBottom={6} key={order.id}>
+		<TableContainer component={Paper} style={{ marginTop: '20px', marginBottom: '20px' }}>
+			<Table aria-label="simple table">
+				<TableHead>
+					<TableRow>
+						<TableCell style={{ fontWeight: 'bold' }}>Order</TableCell>
+						<TableCell style={{ fontWeight: 'bold' }}>Product</TableCell>
+						<TableCell style={{ fontWeight: 'bold' }}>Image</TableCell>
+						<TableCell style={{ fontWeight: 'bold' }}>Quantity</TableCell>
+						<TableCell style={{ fontWeight: 'bold' }}>Price Per Item</TableCell>
+					</TableRow>
+				</TableHead>
+				<TableBody>
+					{orders.map((order: any) => (
+						<React.Fragment key={order.id}>
+							<TableRow>
+								<TableCell colSpan={5} style={{ fontWeight: 'bold' }}>
+									Order #: {order.id}
+								</TableCell>
+							</TableRow>
+							{order.items.map((item: any) => (
+								<TableRow key={item.productSlug}>
+									<TableCell></TableCell>
+									<TableCell>{item.productName}</TableCell>
+									<TableCell>
+										<img
+											loading="lazy"
+											src={item.productImage}
+											alt={item.productName}
+											className="max-w-xs max-h-24"
+											width={100}
+											height={100}
+										/>
+									</TableCell>
+									<TableCell>{item.quantity}</TableCell>
+									<TableCell>${item.price.toFixed(2)}</TableCell>
+								</TableRow>
+							))}
+							<TableRow>
+								<TableCell colSpan={4} style={{ fontWeight: 'bold' }}>
+									Total Price
+								</TableCell>
+								<TableCell>${order.totalPrice.toFixed(2)}</TableCell>
+							</TableRow>
+			  <Divider />
+						</React.Fragment>
+					))}
+				</TableBody>
+			</Table>
+		</TableContainer>
+	<Divider style={{ backgroundColor: 'black', height: '2px', marginTop: '20px', marginBottom: '20px' }} />
+	</Box>
+	))}
+	)
 }
 
 export default StoreOrders


### PR DESCRIPTION
Added thick divider line between different orders on customer and store owner order pages. This example includes orders from different stores.

![Screenshot 2024-04-26 at 3 19 31 PM](https://github.com/ValentinaValverde/Pyme/assets/108947258/0551c890-afd7-4110-b92b-b7b1c37be12c)
